### PR TITLE
Make interdependencies require same binary version

### DIFF
--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -48,7 +48,7 @@ Architecture: any
 Section: libdevel
 Depends: libsqlite3-dev,
          libignition-cmake2-dev,
-         libignition-transport9-core-dev,
+         libignition-transport9-core-dev (= ${binary:Version}),
          libignition-transport9-log (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -65,8 +65,8 @@ Description: Ignition Robotics Transport Library - Log Shared library
 Package: libignition-transport9-dev
 Architecture: any
 Section: libdevel
-Depends: libignition-transport9-core-dev,
-         libignition-transport9-log-dev,
+Depends: libignition-transport9-core-dev (= ${binary:Version}),
+         libignition-transport9-log-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics transport Library - Metapackage

--- a/focal/debian/control
+++ b/focal/debian/control
@@ -48,7 +48,7 @@ Architecture: any
 Section: libdevel
 Depends: libsqlite3-dev,
          libignition-cmake2-dev,
-         libignition-transport9-core-dev,
+         libignition-transport9-core-dev (= ${binary:Version}),
          libignition-transport9-log (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -65,8 +65,8 @@ Description: Ignition Robotics Transport Library - Log Shared library
 Package: libignition-transport9-dev
 Architecture: any
 Section: libdevel
-Depends: libignition-transport9-core-dev,
-         libignition-transport9-log-dev,
+Depends: libignition-transport9-core-dev (= ${binary:Version}),
+         libignition-transport9-log-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics transport Library - Metapackage

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -48,7 +48,7 @@ Architecture: any
 Section: libdevel
 Depends: libsqlite3-dev,
          libignition-cmake2-dev,
-         libignition-transport9-core-dev,
+         libignition-transport9-core-dev (= ${binary:Version}),
          libignition-transport9-log (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
@@ -65,8 +65,8 @@ Description: Ignition Robotics Transport Library - Log Shared library
 Package: libignition-transport9-dev
 Architecture: any
 Section: libdevel
-Depends: libignition-transport9-core-dev,
-         libignition-transport9-log-dev,
+Depends: libignition-transport9-core-dev (= ${binary:Version}),
+         libignition-transport9-log-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics transport Library - Metapackage


### PR DESCRIPTION
Part of ignition-tooling/release-tools#469

Note that the `ubuntu/debian/control` file is symlinked to the `debian/sid` and `debian/buster` folders with a different python version than the control file in the `bionic` and `focal` folders. To avoid changing the python version of any of these packages, I have simply replicated this change over each `control` file. The symlinks have already been unified in version 10+, so I think we can just leave these as is.